### PR TITLE
II-23997   ARI - Add downdetector slugs

### DIFF
--- a/src/insightfinder_mcp_server/server/tools/downdetector_slugs.json
+++ b/src/insightfinder_mcp_server/server/tools/downdetector_slugs.json
@@ -112,6 +112,14 @@
     "slug": "battle-net"
   },
   {
+    "name": "ATT",
+    "slug": "att"
+  },
+  {
+    "name": "AT&T",
+    "slug": "att"
+  },
+  {
     "name": "Bluehost",
     "slug": "bluehost"
   },
@@ -740,6 +748,10 @@
     "slug": "splunk"
   },
   {
+    "name": "Spectrum",
+    "slug": "spectrum"
+  },
+  {
     "name": "Squarespace",
     "slug": "squarespace"
   },
@@ -938,5 +950,41 @@
   {
     "name": "Zscaler",
     "slug": "zscaler"
+  },
+  {
+    "name": "Verizon",
+    "slug": "verizon"
+  },
+  {
+    "name": "t-mobile",
+    "slug": "t-mobile"
+  },
+  {
+    "name": "TMobile",
+    "slug": "t-mobile"
+  },
+  {
+    "name": "xfinity",
+    "slug": "xfinity"
+  },
+  {
+    "name": "cox-communications",
+    "slug": "cox-communications"
+  },
+  {
+    "name": "Cox",
+    "slug": "cox-communications"
+  },
+  {
+    "name": "The Weather Channel",
+    "slug": "the-weather-channel"
+  },
+  {
+    "name": "Weather Channel",
+    "slug": "the-weather-channel"
+  },
+  {
+    "name": "Weather",
+    "slug": "the-weather-channel"
   }
 ]


### PR DESCRIPTION
https://insightfinders.atlassian.net/browse/II-23997
added following downdetector slugs:
Spectrum
ATT
Verizon
Tmobile
Xfinity
Cox
AWS
Google
CloudFlare
Weather